### PR TITLE
fix config

### DIFF
--- a/build-and-publish-plugin.yml
+++ b/build-and-publish-plugin.yml
@@ -17,19 +17,17 @@ install:
 before_script:
   - git config --global user.email "SvcReleaserBackend@yoomoney.ru"
   - git config --global user.name "yoomoney-robot"
-  - echo $GIT_CHECKOUT_KEY | openssl base64 -A -d >> ~/.ssh/git_key_checkout
-  - chmod 400 ~/.ssh/git_key_checkout
+  - echo $GIT_KEY | openssl base64 -A -d >> ~/.ssh/git_key
+  - chmod 400 ~/.ssh/git_key
   - eval `ssh-agent -s`
-  - ssh-add ~/.ssh/git_key_checkout
+  - echo "echo $GIT_KEY_PASSPHRASE" >> $HOME/passphrase
+  - chmod 700 $HOME/passphrase
+  - export DISPLAY=":0.0"
+  - cat ~/.ssh/git_key | SSH_ASKPASS="$HOME/passphrase" ssh-add -
   - git clone --depth=50 --branch=$TRAVIS_BRANCH git@github.com:$TRAVIS_REPO_SLUG.git $TRAVIS_REPO_SLUG
   - cd $TRAVIS_REPO_SLUG
   - git checkout -f $TRAVIS_BRANCH
-  # Decrypt the git_key.enc key into git_key
-  - |
-    if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then
-        echo $GIT_KEY | openssl base64 -A -d >> $TRAVIS_BUILD_DIR/git_key
-    fi
-  - export GIT_PRIVATE_SSH_KEY_PATH=$TRAVIS_BUILD_DIR/git_key
+  - export GIT_PRIVATE_SSH_KEY_PATH=~/.ssh/git_key
 
 jobs:
   include:

--- a/build-and-publish-plugin.yml
+++ b/build-and-publish-plugin.yml
@@ -5,6 +5,9 @@ jdk:
 env:
   - TERM=dumb
 
+git:
+  clone: false
+
 #Below skips the installation step completely (https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step)
 #We need it because otherwise Travis CI injects an awkward './gradlew assemble' step into the CI workflow
 #We want to control and decide what Gradle tasks are executed
@@ -14,11 +17,17 @@ install:
 before_script:
   - git config --global user.email "SvcReleaserBackend@yoomoney.ru"
   - git config --global user.name "yoomoney-robot"
+  - echo $GIT_CHECKOUT_KEY | openssl base64 -A -d >> ~/.ssh/git_key_checkout
+  - chmod 400 ~/.ssh/git_key_checkout
+  - eval `ssh-agent -s`
+  - ssh-add ~/.ssh/git_key_checkout
+  - git clone --depth=50 --branch=$TRAVIS_BRANCH git@github.com:$TRAVIS_REPO_SLUG.git $TRAVIS_REPO_SLUG
+  - cd $TRAVIS_REPO_SLUG
   - git checkout -f $TRAVIS_BRANCH
   # Decrypt the git_key.enc key into git_key
   - |
     if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then
-        openssl aes-256-cbc -k $GIT_PRIVATE_KEY_PASS -in git_key.enc -out git_key -d
+        echo $GIT_KEY | openssl base64 -A -d >> $TRAVIS_BUILD_DIR/git_key
     fi
   - export GIT_PRIVATE_SSH_KEY_PATH=$TRAVIS_BUILD_DIR/git_key
 


### PR DESCRIPTION
для корректного push при выпуске релиза нужен checkout от имени robot.
для этого отключаем стандартный clone и делаем сами с нужным ключом.

также shh key теперь хранится в переменной 