### PR TITLE
Добавлен флаг для refresh зависимостей

### DIFF
--- a/build-and-publish-plugin.yml
+++ b/build-and-publish-plugin.yml
@@ -39,17 +39,17 @@ jobs:
   include:
     - stage: build
       script:
-        - ./gradlew -b build.gradle clean build test publish --info
+        - ./gradlew -b build.gradle clean build test publish --info --stacktrace --refresh-dependencies
     - stage: release
       if: branch = master
       script:
         - |
-          ./gradlew -b build.gradle preRelease --info -D"gradle.publish.key"=$GRADLE_PUBLISH_KEY -D"gradle.publish.secret"=$GRADLE_PUBLISH_SECRET
+          ./gradlew -b build.gradle preRelease --info  --stacktrace --refresh-dependencies -D"gradle.publish.key"=$GRADLE_PUBLISH_KEY -D"gradle.publish.secret"=$GRADLE_PUBLISH_SECRET
           if [ $? != 0 ]
           then
            exit 1
           fi
-          ./gradlew -b build.gradle release --info -D"gradle.publish.key"=$GRADLE_PUBLISH_KEY -D"gradle.publish.secret"=$GRADLE_PUBLISH_SECRET
+          ./gradlew -b build.gradle release --info --stacktrace --refresh-dependencies -D"gradle.publish.key"=$GRADLE_PUBLISH_KEY -D"gradle.publish.secret"=$GRADLE_PUBLISH_SECRET
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
при старте сборок он не нужен, а вот когда происходит rebuild - новые сборки не подхватываются